### PR TITLE
Fix : execute command using /bin/sh

### DIFF
--- a/main.go
+++ b/main.go
@@ -70,7 +70,7 @@ func execCmd(path string, req request) result {
 		started: time.Now(),
 		request: req,
 	}
-	cmd := exec.Command(req.command[0], req.command[1:]...)
+	cmd := exec.Command("/bin/sh", "-c", strings.Join(req.command, " "))
 	cmd.Dir = path
 	cmd.Stdout = &r.stdout
 	cmd.Stderr = &r.stderr


### PR DESCRIPTION
This is done to be able to use quoted command with, inside, pipe for example.

Since `flag.Args()` returns a slice of string if the croncape args (the command) is quoted, `req.command[0]` contains the full quoted string and this is what is passed to `exec.Command()`.

So, when exec.Command() try to execute it fails.

Here is an example : 

```sh
$ croncape "ls -lsa | wc -l"

exec: "ls -lsa | wc -l": executable file not found in $PATH
```

This pull request change the way commands are executed by passing the command as an argument of `/bin/sh -c`